### PR TITLE
search

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,18 +2,4 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
-  before_action :modal
-
-  def modal
-    if params[:search_destination]
-      @destinations = Destination.search(params[:search_destination])
-      if @destinations.blank?
-        flash[:notice] = 'We were unable to locate your search results'
-        redirect_to :back
-      end
-    else
-    @destinations = Destination.all.order('site ASC')
-    end
-  end
-
 end

--- a/app/controllers/destinations_controller.rb
+++ b/app/controllers/destinations_controller.rb
@@ -5,16 +5,15 @@ class DestinationsController < ApplicationController
   # GET /destinations.json
   def index
     if params[:search_destination]
-      @destinations = Destination.search(params[:search_destination])
-      if @destinations.blank?
-        flash[:notice] = 'We were unable to locate your search results'
-        redirect_to :back
+      if Destination.search(params[:search_destination]).blank?
+        @destinations = Destination.all
+        flash[:notice] = "There were no results for #{params[:search_destination]}"
+      else
+        @destinations = Destination.search(params[:search_destination])
       end
     else
-    @destinations = Destination.all.order('site ASC')
+      @destinations = Destination.all
     end
-    url = 'https://maps.googleapis.com/maps/api/js?key='
-    key = ENV['GOOGLE_MAPS']
   end
 
   # GET /destinations/1

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -1,9 +1,5 @@
 class Destination < ActiveRecord::Base
 
-  def lodging
-    self.activities == nil ? self.activities = "lodging" : self.activities
-  end
-
   def category_type
     self.category == "NP" ? self.category = "Nature Preserve" : self.category
   end

--- a/app/views/destinations/_show_destination.html.erb
+++ b/app/views/destinations/_show_destination.html.erb
@@ -8,7 +8,7 @@
       <div class="modal-body">
         <p><%= image_tag(destination.picture_url, class: "img-modal center-block") %></p>
         <p> <h3> <%= destination.category_type %> </h3> </p>
-        <p class="site-modal-info"> Activities: <%= destination.lodging %> </p>
+        <p class="site-modal-info"> Activities: <%= destination.activities %> </p>
         <p class ="site-modal-info"> <%= link_to "More Info on #{destination.site}", destination.website_url, target: :blank %> </p>
       </div>
       <div class="modal-footer">

--- a/app/views/destinations/index.html.erb
+++ b/app/views/destinations/index.html.erb
@@ -54,7 +54,7 @@
 
 </section>
 
-<section class="section3">
+<section class="section3" id="section3">
   <ul class="clearfix list-unstyled">
   <% if params[:search_destination] %>
     <li><h1 class="text-center"> Listing Search Results for <%=params[:search_destination] %></h1></li>

--- a/lib/get_destination.rb
+++ b/lib/get_destination.rb
@@ -14,8 +14,14 @@ class DestinationGrabber
     puts data.inspect
     data.each do |info|
 
+      if info["activities"].blank?
+        @activities = "Lodging"
+      else
+        @activities = info["activities"]
+      end
 
-      Destination.create!(activities: info["activities"],
+
+      Destination.create!(activities: @activities,
                           location: info["park_location"],
                           latitude: info["location_1"]["coordinates"][0],
                           longitude: info["location_1"]["coordinates"][1],


### PR DESCRIPTION
search works as it should, if you search for a certain activity it returns those sites in both the section with the picture and are the only sites that show up on the map.
If you search for an activity that does not exist it will return all the sites.  All of the sites is the default.
The seed file has been fixed so all the sites that did not have activities in the api now have lodging as the activity(all other sites have the correct activity)
section3, where the pictures, is now hrefed correctly to locate link in the navbar
